### PR TITLE
Specify attribute type for FeatureCounts single step

### DIFF
--- a/config/single_steps_config.yaml
+++ b/config/single_steps_config.yaml
@@ -23,6 +23,10 @@ feature_counts:
     # Count reads at 'feature' level (each exon) or for whole gene (put sth other than "feature")
     count_at: "gene"
 
+    # What identifier in GTF to use for constructing meta-features if counting at the gene level
+    # usually 'gene_id' is best
+    attribute_type: "gene_id"
+
     # No need to change this
     feature_counts_path: /SAN/vyplab/alb_projects/tools/subread-1.6.4-Linux-x86_64/bin/featureCounts
 

--- a/single_steps/feature_counts.smk
+++ b/single_steps/feature_counts.smk
@@ -52,7 +52,7 @@ rule feature_counts:
         stranded = feature_counts_strand_info,
         feature_counts = feature_counts_path,
         feature_type = "exon", # exons extracted for counting from ref_anno
-        attr_type = options["attribute_type"], # Generate meta-features for counting via this group/id
+        attr_type = options_dict["attribute_type"], # Generate meta-features for counting via this group/id
         extra_attr = ",".join(["gene_name"]), # extra metadata to extract & report in count output
         count_level = "-f" if options_dict["count_at"] == "feature" else "", # count at exon or gene level?
         paired_end = "-p" if end_type == "pe" else "" #count fragments if paired end

--- a/single_steps/feature_counts.smk
+++ b/single_steps/feature_counts.smk
@@ -51,8 +51,8 @@ rule feature_counts:
         ref_anno = gtf,
         stranded = feature_counts_strand_info,
         feature_counts = feature_counts_path,
-        feature_type = "exon", # expns extracted for counting from ref_anno
-        attr_type = "gene_id", # Generate meta-features for counting via this group/id
+        feature_type = "exon", # exons extracted for counting from ref_anno
+        attr_type = options["attribute_type"], # Generate meta-features for counting via this group/id
         extra_attr = ",".join(["gene_name"]), # extra metadata to extract & report in count output
         count_level = "-f" if options_dict["count_at"] == "feature" else "", # count at exon or gene level?
         paired_end = "-p" if end_type == "pe" else "" #count fragments if paired end


### PR DESCRIPTION
Super quick change allowing to specify the id column for grouping features/generating meta-features at the gene level.

Usually this is gene_id for counting across exons, and I've left that as the default. I was messing around with some custom regions and needed to change this, so the option is there now...

@aleighbrown pinging you so you know