### PR TITLE
Skip merge_trimmed if one unit, gene_body_coverage job per sample & salmon single end rule

### DIFF
--- a/config/cluster.yaml
+++ b/config/cluster.yaml
@@ -88,10 +88,17 @@ salmon_index:
     h_vmem:   10G
     tmem:   10G
     h_rt: 24:00:00
-salmon_quant:
-    submission_string: " "
-    h_vmem:   32G
-    tmem:   32G
+salmon_quant_pe:
+    submission_string: "-pe smp 4 -R y"
+    h_vmem:   8G
+    tmem:   8G
+    smp: 4
+    h_rt: 72:00:00
+salmon_quant_se:
+    submission_string: "-pe smp 4 -R y"
+    h_vmem:   8G
+    tmem:   8G
+    smp: 4
     h_rt: 72:00:00
 scallop_per_samp:
     h_vmem:   8G

--- a/config/test_se_config.yaml
+++ b/config/test_se_config.yaml
@@ -98,6 +98,14 @@ star_path: /SAN/vyplab/alb_projects/tools/STAR/bin/Linux_x86_64_static/STAR
 ## SALMON PARAMETERS
 #########################
 
+# Note: if you're quantifying single-end libraries, fragment sizes cannot be estimated from the mates
+# THese two options become extra important
+# The defaults should be sufficient in most cases, but I haven't played around with this too much
+#  --fldMean arg (=250)                  The mean used in the fragment length
+#                                        distribution prior
+#  --fldSD arg (=25)                     The standard deviation used in the
+#                                        fragment length distribution prior
+
 
 extra_salmon_parameters:
   gcBias:

--- a/rules/fastp.smk
+++ b/rules/fastp.smk
@@ -20,8 +20,8 @@ SAMPLE_NAMES = SAMPLES['sample_name'].tolist()
 
 rule merge_all_trimmed:
     input:
-        expand(fastp_outdir + "{unit}_{name}_R1_trimmed.fastq.gz",zip, unit = UNITS,name = SAMPLE_NAMES),
-        expand(fastp_outdir + "{unit}_{name}_R2_trimmed.fastq.gz" if config["end_type"] == "pe" else [],zip, unit = UNITS,name = SAMPLE_NAMES),
+        expand(fastp_outdir + "{unit}_{name}_1.trimmed.fastq.gz",zip, unit = UNITS,name = SAMPLE_NAMES),
+        expand(fastp_outdir + "{unit}_{name}_2.trimmed.fastq.gz" if config["end_type"] == "pe" else [],zip, unit = UNITS,name = SAMPLE_NAMES),
         expand(merged_outdir + "{name}_1.merged.fastq.gz", name = SAMPLE_NAMES),
         expand(merged_outdir + "{name}_2.merged.fastq.gz" if config["end_type"] == "pe" else [],name = SAMPLE_NAMES)
     wildcard_constraints:
@@ -40,8 +40,8 @@ if config['end_type'] == "pe":
         conda:
             "../env/align.yaml"
         output:
-            out_fastqc = fastp_outdir + "{unit}_{name}_R1_trimmed.fastq.gz",
-            out_fastqc2 = fastp_outdir + "{unit}_{name}_R2_trimmed.fastq.gz",
+            out_fastqc = fastp_outdir + "{unit}_{name}_1.trimmed.fastq.gz",
+            out_fastqc2 = fastp_outdir + "{unit}_{name}_2.trimmed.fastq.gz",
             fastpjson = fastp_outdir + "{unit}_{name}_fastp.json",
             fastphtml = fastp_outdir + "{unit}_{name}_fastp.html",
         params:
@@ -64,7 +64,7 @@ else:
             conda:
                 "../env/align.yml"
             output:
-                out_fastqc = fastp_outdir + "{unit}_{name}_R1_trimmed.fastq.gz",
+                out_fastqc = fastp_outdir + "{unit}_{name}_1.trimmed.fastq.gz",
                 fastpjson = fastp_outdir + "{unit}_{name}_fastp.json",
                 fastphtml = fastp_outdir + "{unit}_{name}_fastp.html",
             params:

--- a/rules/fastp.smk
+++ b/rules/fastp.smk
@@ -48,10 +48,22 @@ if config['end_type'] == "pe":
             fastp_parameters = return_parsed_extra_params(config['fastp_parameters']),
             fastpjson = fastp_outdir + "{unit}_{name}_fastp.json",
             fastphtml = fastp_outdir + "{unit}_{name}_fastp.html"
+
+        log:
+            os.path.join(config['project_top_level'], "logs", "{unit}_{name}.fastp_stdout.log")
+
         shell:
             """
             free -h
-            {config[fastp_path]} --in1 {input.fastq_file} --in2 {input.fastq_file2} --out1 {output.out_fastqc} --out2 {output.out_fastqc2} --json {output.fastpjson} --html {output.fastphtml} {params.fastp_parameters}
+            {config[fastp_path]} \
+            --in1 {input.fastq_file} \
+            --in2 {input.fastq_file2} \
+            --out1 {output.out_fastqc} \
+            --out2 {output.out_fastqc2} \
+            --json {output.fastpjson} \
+            --html {output.fastphtml} \
+            {params.fastp_parameters} \
+            2> {log}
             """
 else:
         rule fastp_trimming:
@@ -62,7 +74,7 @@ else:
                 name="|".join(SAMPLE_NAMES),
                 unit="|".join(UNITS)
             conda:
-                "../env/align.yml"
+                "../env/align.yaml"
             output:
                 out_fastqc = fastp_outdir + "{unit}_{name}_1.trimmed.fastq.gz",
                 fastpjson = fastp_outdir + "{unit}_{name}_fastp.json",
@@ -73,9 +85,18 @@ else:
             #out_fastqc2 = lambda wildcards: return_fastq2_name(wildcards.name,wildcards.unit),
                 fastpjson = fastp_outdir + "{unit}_{name}_fastp.json",
                 fastphtml = fastp_outdir + "{unit}_{name}_fastp.html"
+
+            log:
+                os.path.join(config['project_top_level'], "logs", "{unit}_{name}.fastp_stdout.log")
+
             shell:
                 """
-                {config[fastp_path]} -i {input.fastq_file} -o {output.out_fastqc} --json {output.fastpjson} --html {output.fastphtml} {params.fastp_parameters}
+                {config[fastp_path]} -i {input.fastq_file} \
+                -o {output.out_fastqc} \
+                --json {output.fastpjson} \
+                --html {output.fastphtml} \
+                {params.fastp_parameters} \
+                2> {log}
                 """
 
 if config['end_type'] == "pe":

--- a/rules/helpers.py
+++ b/rules/helpers.py
@@ -119,7 +119,7 @@ def get_processed_fastq(sample_name, pair=1, pair_prefix="_", trimmed_suffix=".t
     SAMPLES = pd.read_csv(config["sampleCSVpath"])
     SAMPLES = SAMPLES.replace(np.nan, '', regex=True)
 
-    if SAMPLES.loc[SAMPLES["sample_name"] == "sample_name", "unit"].nunique() > 1:
+    if SAMPLES.loc[SAMPLES["sample_name"] == sample_name, "unit"].nunique() > 1:
         # sample had multiple fastq files, so need to point to merged FASTQ
         target_fastq = os.path.join(merged_outdir, sample_name + rpair_str + merged_suffix)
 

--- a/rules/helpers.py
+++ b/rules/helpers.py
@@ -316,9 +316,9 @@ def multiqc_target_files(workflow_str, sample_names, fastq_prefixes, units):
         targets_star = expand(star_outdir + "{name}.flagstat.txt", name = sample_names)
         targets_salmon = expand(salmon_outdir + "{sample}/" + "quant.sf", sample = sample_names)
 
-        rseq_target_suffixes = [".infer_experiment.txt", ".inner_distance_freq.txt", ".junctionSaturation_plot.r", ".read_distribution.txt"]
+        rseq_target_suffixes = [".geneBodyCoverage.txt", ".infer_experiment.txt", ".inner_distance_freq.txt", ".junctionSaturation_plot.r", ".read_distribution.txt"]
         targets_rseqc = expand(rseqc_outdir + "{name}" + "{suffix}", name = sample_names, suffix = rseq_target_suffixes)
-        targets_rseqc.append(os.path.join(rseqc_outdir, "all_bams_output.geneBodyCoverage.txt"))
+        # targets_rseqc.append(os.path.join(rseqc_outdir, "all_bams_output.geneBodyCoverage.txt"))
 
 
         if workflow_str == "fastq_qc":
@@ -355,7 +355,7 @@ def multiqc_target_dirs():
     '''
     Returns list of paths to directories for multiqc to scan for log files
     Since it scan recursively through dirs, and only penalty to searching extra dirs is added run-time
-    For simplicity, this returns paths to all potential directories, provided they exist / have been created
+    For simplicity, this returns paths to all potential directories of different workflows, provided they exist / have been created
     '''
 
     outdir_keys = ["fastqc_output_folder", "fastp_trimmed_output_folder", "star_output_folder", "salmon_output_folder", "rseqc_output_folder", "feature_counts_output_folder"]

--- a/rules/rseqc.smk
+++ b/rules/rseqc.smk
@@ -40,7 +40,7 @@ SAMPLE_NAMES = SAMPLES['sample_name'].tolist()
 
 rule all_rseqc:
     input:
-        os.path.join(RSEQC_OUTDIR, "all_bams_output.geneBodyCoverage.txt"), #gene_body_coverage
+        expand(RSEQC_OUTDIR + "{sample}.geneBodyCoverage.txt", sample = SAMPLE_NAMES), #gene_body_coverage
         expand(RSEQC_OUTDIR + "{sample}.infer_experiment.txt", sample = SAMPLE_NAMES), #infer_experiment
         expand(RSEQC_OUTDIR + "{sample}.inner_distance_freq.txt", sample = SAMPLE_NAMES), # inner_distance
         expand(RSEQC_OUTDIR + "{sample}.junctionSaturation_plot.r", sample = SAMPLE_NAMES), # junction_saturation
@@ -52,16 +52,16 @@ rule all_rseqc:
 
 rule gene_body_coverage:
     input:
-        bams = expand(STAR_OUTDIR + "{sample}.Aligned.sorted.out.bam", sample = SAMPLE_NAMES),
-        idxs = expand(STAR_OUTDIR + "{sample}.Aligned.sorted.out.bam.bai", sample = SAMPLE_NAMES)
+        bam = STAR_OUTDIR + "{sample}.Aligned.sorted.out.bam",
+        idx = STAR_OUTDIR + "{sample}.Aligned.sorted.out.bam.bai"
 
     output:
-        os.path.join(RSEQC_OUTDIR, "all_bams_output.geneBodyCoverage.txt")
+        os.path.join(RSEQC_OUTDIR, "{sample}.geneBodyCoverage.txt")
 
     params:
-        samples = lambda wildcards, input: ",".join(input.bams),
+        # samples = lambda wildcards, input: ",".join(input.bams),
         annotation = BED12,
-        prefix = os.path.join(RSEQC_OUTDIR, "all_bams_output")
+        prefix = os.path.join(RSEQC_OUTDIR, "{sample}")
 
     conda:
         "../env/align.yaml"
@@ -69,7 +69,7 @@ rule gene_body_coverage:
     shell:
         """
         geneBody_coverage.py \
-        -i {params.samples} \
+        -i {input.bam} \
         -r {params.annotation} \
         -l 100 \
         -o {params.prefix}

--- a/rules/salmon_quant.smk
+++ b/rules/salmon_quant.smk
@@ -1,10 +1,26 @@
 import os
 import pandas as pd
 import numpy as np
+import yaml
 
 configfile: "config/config.yaml"
 cluster_config: "config/cluster.yaml"
 include: "helpers.py"
+
+# I shouldn't be doing this - can't work why cluster_config[<rule name>] returns a key error...
+# Dirty, easy way out
+with open("config/cluster.yaml", "r") as stream:
+    cluster_dict = yaml.safe_load(stream)
+
+
+
+# RULE ORDER DIRECTIVE
+# if paired end, use the paired end rule to run, if single end use the single end rule to run
+if config['end_type'] == "pe":
+    ruleorder: salmon_quant_pe > salmon_quant_se
+else:
+    ruleorder: salmon_quant_se > salmon_quant_pe
+
 
 ## Define target salmon transcriptome index
 
@@ -65,7 +81,7 @@ rule salmon_quant_all:
         expand(OUTPUT_DIR + "{sample}/" + "quant.sf", sample = SAMPLE_NAMES)
 
 
-rule salmon_quant:
+rule salmon_quant_pe:
     input:
         fast1 = FASTQ_DIR  + "{sample}_1.merged.fastq.gz",
         fast2 = FASTQ_DIR  + "{sample}_2.merged.fastq.gz",
@@ -80,7 +96,8 @@ rule salmon_quant:
         output_dir = os.path.join(OUTPUT_DIR, "{sample}"),
         libtype = get_salmon_strand(config["feature_counts_strand_info"]),
         gtf = get_gtf(SPECIES),
-        extra_params = return_parsed_extra_params(config["extra_salmon_parameters"])
+        extra_params = return_parsed_extra_params(config["extra_salmon_parameters"]),
+        threads = cluster_dict["salmon_quant_pe"]["smp"]
 
     # threads: 4
 
@@ -92,6 +109,36 @@ rule salmon_quant:
         --mates1 {input.fast1} \
         --mates2 {input.fast2} \
         --geneMap {params.gtf} \
+        --threads {params.threads} \
+        {params.extra_params} \
+        -o {params.output_dir} \
+        """
+
+rule salmon_quant_se:
+    input:
+        fast1 = merged_outdir + "{sample}_1.merged.fastq.gz",
+        index = os.path.join(TXOME_DIR, "seq.bin")
+
+    output:
+        os.path.join(OUTPUT_DIR, "{sample}", "quant.sf")
+
+    params:
+        salmon = config["salmon_path"],
+        index_dir = TXOME_DIR,
+        output_dir = os.path.join(OUTPUT_DIR, "{sample}"),
+        libtype = get_salmon_strand(config["feature_counts_strand_info"]),
+        gtf = get_gtf(SPECIES),
+        extra_params = return_parsed_extra_params(config["extra_salmon_parameters"]),
+        threads = cluster_dict["salmon_quant_se"]["smp"]
+
+    shell:
+        """
+        {params.salmon} quant \
+        --index {params.index_dir} \
+        --libType {params.libtype} \
+        -r {input.fast1} \
+        --geneMap {params.gtf} \
+        --threads {params.threads} \
         {params.extra_params} \
         -o {params.output_dir} \
         """

--- a/rules/salmon_quant.smk
+++ b/rules/salmon_quant.smk
@@ -83,8 +83,8 @@ rule salmon_quant_all:
 
 rule salmon_quant_pe:
     input:
-        fast1 = FASTQ_DIR  + "{sample}_1.merged.fastq.gz",
-        fast2 = FASTQ_DIR  + "{sample}_2.merged.fastq.gz",
+        fast1 = lambda wildcards: get_processed_fastq(wildcards.sample, pair=1),
+        fast2 = lambda wildcards: get_processed_fastq(wildcards.sample, pair=2),
         index = os.path.join(TXOME_DIR, "seq.bin")
 
     output:
@@ -116,7 +116,7 @@ rule salmon_quant_pe:
 
 rule salmon_quant_se:
     input:
-        fast1 = merged_outdir + "{sample}_1.merged.fastq.gz",
+        fast1 = lambda wildcards: get_processed_fastq(wildcards.sample, pair=1),
         index = os.path.join(TXOME_DIR, "seq.bin")
 
     output:

--- a/rules/star.smk
+++ b/rules/star.smk
@@ -40,8 +40,8 @@ rule run_star_pe:
 		sample="|".join(SAMPLE_NAMES)
 	input:
 		generated_index = GENOME_DIR + "/SA",
-		one = merged_outdir + "{name}_1.merged.fastq.gz",
-		two = merged_outdir + "{name}_2.merged.fastq.gz"
+		one = lambda wildcards: get_processed_fastq(wildcards.name, pair=1),
+		two = lambda wildcards: get_processed_fastq(wildcards.name, pair=2)
 	output:
 		star_outdir + "{name}.SJ.out.tab",
 		star_outdir + "{name}.Log.final.out",
@@ -67,7 +67,7 @@ rule run_star_pe:
 rule run_star_se:
 	input:
 		generated_index = GENOME_DIR + "/SA",
-		one = merged_outdir + "{name}_1.merged.fastq.gz"
+		one = lambda wildcards: get_processed_fastq(wildcards.name, pair=1)
 	output:
 		star_outdir + "{name}.SJ.out.tab",
 		star_outdir + "{name}.Log.final.out",

--- a/rules/transcriptome_assembly_extract_quantify.smk
+++ b/rules/transcriptome_assembly_extract_quantify.smk
@@ -146,8 +146,8 @@ rule salmon_index_extended:
 
 rule salmon_quant:
     input:
-        fast1 = FASTQ_DIR  + "{sample}_1.merged.fastq.gz",
-        fast2 = FASTQ_DIR  + "{sample}_2.merged.fastq.gz",
+        fast1 = lambda wildcards: get_processed_fastq(wildcards.sample, pair=1),
+        fast2 = lambda wildcards: get_processed_fastq(wildcards.sample, pair=1),
         index = os.path.join(scallop_outdir, "extended_transcriptome/seq.bin"),
         scallop_ref = os.path.join(scallop_outdir,"scallop.tx_gene.tsv")
     output:

--- a/submit.sh
+++ b/submit.sh
@@ -11,7 +11,7 @@
 #$ -j y
 #$ -R y
 
-source activate /SAN/vyplab/vyplab_reference_genomes/conda_envs/splicing_env/
+# source activate /SAN/vyplab/vyplab_reference_genomes/conda_envs/splicing_env/
 
 WORKFLOW="workflows/${1}.smk"
 

--- a/workflows/align.smk
+++ b/workflows/align.smk
@@ -41,7 +41,7 @@ rule all:
     input:
         GENOME_DIR + "/SA",
         expand(feature_counts_outdir + "{name}_featureCounts_results.txt", name = SAMPLE_NAMES),
-        expand(tpm_outdir + "{name}" + suffix + "_genes.out", name = SAMPLE_NAMES),
+        # expand(tpm_outdir + "{name}" + suffix + "_genes.out", name = SAMPLE_NAMES),
         expand(star_outdir + "{name}.Aligned.sorted.out.bam", name = SAMPLE_NAMES),
         expand(star_outdir + "{name}.Aligned.sorted.out.bam.bai", name = SAMPLE_NAMES),
         os.path.join(multiqc_output_folder, "multiqc_report.html")

--- a/workflows/salmon.smk
+++ b/workflows/salmon.smk
@@ -43,6 +43,7 @@ include: "../rules/multiqc.smk"
 rule all:
     input:
         expand(salmon_outdir + "{sample}/" + "quant.sf", sample = SAMPLE_NAMES),
+        os.path.join(multiqc_output_folder, "multiqc_report.html")
         #os.path.join(TXOME_DIR, "seq.bin"),
         #os.path.join(TXOME_DIR, "pos.bin")
         #expand(fastqc_outdir + "{unit}/{fastq_name}_fastqc.html",zip, fastq_name=FASTQ_NAME, unit=UNITS)


### PR DESCRIPTION
Forgot to merge salmon single end updates from < Easter, so bumped into this branch.

1. Rules using processed FASTQs (e.g. STAR, Salmon etc.) now have input FASTQs defined by a input function (`get_processed_fastq()` under `rules/helpers.py`). If sample only has one unit, merge_trimmed is skipped and the rule uses the trimmed FASTQ as input, otherwise the merged file is used as input. Closes #9 
2. Added rule for single end Salmon quantification. I *think* I tested it back in March...
3.  gene_body_coverage now runs with job per-sample vs all BAMs at once. It completes successfully but is **very slow**. Should consider swapping out for a quicker tool. Closes #22 

Did a test run with the small test paired end data and everything completes successfully.