### PR TITLE
get_trimmed looks for correct suffix. Switch order of r1 & r2 merging…

### DIFF
--- a/rules/fastp.smk
+++ b/rules/fastp.smk
@@ -115,8 +115,8 @@ if config['end_type'] == "pe":
             two = lambda wildcards: ' '.join(get_trimmed(wildcards.name)[1])
         shell:
             """
-            cat {params.two} > {output.out_two}
             cat {params.one} > {output.out_one}
+            cat {params.two} > {output.out_two}
             """
 else:
     rule merge_trimmed:

--- a/rules/helpers.py
+++ b/rules/helpers.py
@@ -62,12 +62,12 @@ def get_trimmed(name):
     unit_fastqs = SAMPLES.loc[(SAMPLES.sample_name == name),'unit'].tolist()
     unit_fastqs2 = [u + "_" + name for u in unit_fastqs]
 
-    trimmed_1 = [os.path.join(fastp_outdir,u + "_R1_trimmed.fastq.gz") for u in unit_fastqs2]
+    trimmed_1 = [os.path.join(fastp_outdir,u + "_1.trimmed.fastq.gz") for u in unit_fastqs2]
 
 
     #if we have paired end data there will also be a trimmed 2, same thing, using the fast2 column instead
     if config['end_type'] == "pe":
-        trimmed_2 = [os.path.join(fastp_outdir,u + "_R2_trimmed.fastq.gz") for u in unit_fastqs2]
+        trimmed_2 = [os.path.join(fastp_outdir,u + "_2.trimmed.fastq.gz") for u in unit_fastqs2]
 
         #trimmed files is a list of the two
         trimmed_files = [trimmed_1, trimmed_2]


### PR DESCRIPTION
fixes #32 - had made the change locally but not committed for some reason.

This matches up the filenames that `get_trimmed` outputs with the updated suffixes output by `fastp`. Haven't tested at all but should work. Please double check.

I also included a quick formatting change in `rules/fastp.smk` that was bugging me.