### PR TITLE
Fix MultiQC report missing RSeQC output bug

### DIFF
--- a/rules/helpers.py
+++ b/rules/helpers.py
@@ -354,7 +354,7 @@ def multiqc_target_dirs():
     '''
     Returns list of paths to directories for multiqc to scan for log files
     Since it scan recursively through dirs, and only penalty to searching extra dirs is added run-time
-    For simplicity, this returns paths to all potential directories of different workflows, provided they exist / have been created
+    For simplicity, this returns paths to all potential directories of different workflows, provided they exist / have been created prior to the DAG being generated
     '''
 
     outdir_keys = ["fastqc_output_folder", "fastp_trimmed_output_folder", "star_output_folder", "salmon_output_folder", "rseqc_output_folder"]
@@ -364,9 +364,10 @@ def multiqc_target_dirs():
 
     # print("this is all_dir_paths for multiqc {0}".format(",".join(all_dir_paths)))
     # Return only potential directories that have already exist
+    # The directory must be made in the snakefile prior to the rule being run for this to work (otherwise the path doesn't exist when the DAG is generated)
     target_dir_paths = [p for p in all_dir_paths if os.path.exists(p)]
 
-    # print("this is target_dir_paths for multiqc - {0}".format(",".join(all_dir_paths)))
+    # print("this is target_dir_paths for multiqc - {0}".format(",".join(target_dir_paths)))
 
     return target_dir_paths
 

--- a/rules/rseqc.smk
+++ b/rules/rseqc.smk
@@ -28,6 +28,9 @@ STAR_OUTDIR = get_output_dir(config["project_top_level"], config['star_output_fo
 RSEQC_OUTDIR = get_output_dir(config["project_top_level"], config["rseqc_output_folder"])
 SPECIES = config["species"]
 
+#make sure the output folder for rseqc exists before running anything
+os.system("mkdir -p {0}".format(RSEQC_OUTDIR))
+
 # RSeQC wants annotation in BED12 format. This can be pulled from refence_files_species
 BED12 = get_bed12(SPECIES)
 


### PR DESCRIPTION
Fixes #51 

The problem is that `multiqc_target_dirs` checks that the potential logfile/search directories already exist before passing the list of directories fro MultiQC to check for log/output files. This was intended to cover cases where we ran different workflows that do not include certain rules, so there'd be no need to check those directories (possibly also prevented errors with MultiQC if provided paths didn't exist...)

However, `rules/rseqc.smk` did not create the target output directory prior to the DAG/rulegraph being generated (rather relying on Snakemake to generate it as the rules are executed). This meant that the rseqc output directory didn't exist at run time and so was not passed to multiqc.

This PR adds a fix to this bug (and extra warning comments in the function docstring).

MultiQC report with our test data now includes the rseqc output
![image](https://user-images.githubusercontent.com/49978382/204350555-973c7d52-4648-411a-830e-a14c6a420235.png)
