### PR TITLE
Remove geneBody_coverage.py (runs incredibly slowly)

### DIFF
--- a/rules/helpers.py
+++ b/rules/helpers.py
@@ -315,7 +315,8 @@ def multiqc_target_files(workflow_str, sample_names, fastq_prefixes, units):
         targets_star = expand(star_outdir + "{name}.flagstat.txt", name = sample_names)
         targets_salmon = expand(salmon_outdir + "{sample}/" + "quant.sf", sample = sample_names)
 
-        rseq_target_suffixes = [".geneBodyCoverage.txt", ".infer_experiment.txt", ".inner_distance_freq.txt", ".junctionSaturation_plot.r", ".read_distribution.txt"]
+        rseq_target_suffixes = [".infer_experiment.txt", ".inner_distance_freq.txt", ".junctionSaturation_plot.r", ".read_distribution.txt"]
+        # ".geneBodyCoverage.txt" - add back to list above if want to return to calculating gene body coverage (not recommended, very slow...)
         targets_rseqc = expand(rseqc_outdir + "{name}" + "{suffix}", name = sample_names, suffix = rseq_target_suffixes)
         # targets_rseqc.append(os.path.join(rseqc_outdir, "all_bams_output.geneBodyCoverage.txt"))
 

--- a/rules/rseqc.smk
+++ b/rules/rseqc.smk
@@ -43,7 +43,7 @@ SAMPLE_NAMES = SAMPLES['sample_name'].tolist()
 
 rule all_rseqc:
     input:
-        expand(RSEQC_OUTDIR + "{sample}.geneBodyCoverage.txt", sample = SAMPLE_NAMES), #gene_body_coverage
+        # expand(RSEQC_OUTDIR + "{sample}.geneBodyCoverage.txt", sample = SAMPLE_NAMES), #gene_body_coverage
         expand(RSEQC_OUTDIR + "{sample}.infer_experiment.txt", sample = SAMPLE_NAMES), #infer_experiment
         expand(RSEQC_OUTDIR + "{sample}.inner_distance_freq.txt", sample = SAMPLE_NAMES), # inner_distance
         expand(RSEQC_OUTDIR + "{sample}.junctionSaturation_plot.r", sample = SAMPLE_NAMES), # junction_saturation
@@ -53,30 +53,30 @@ rule all_rseqc:
 ##
 
 
-rule gene_body_coverage:
-    input:
-        bam = STAR_OUTDIR + "{sample}.Aligned.sorted.out.bam",
-        idx = STAR_OUTDIR + "{sample}.Aligned.sorted.out.bam.bai"
+# rule gene_body_coverage:
+#     input:
+#         bam = STAR_OUTDIR + "{sample}.Aligned.sorted.out.bam",
+#         idx = STAR_OUTDIR + "{sample}.Aligned.sorted.out.bam.bai"
 
-    output:
-        os.path.join(RSEQC_OUTDIR, "{sample}.geneBodyCoverage.txt")
+#     output:
+#         os.path.join(RSEQC_OUTDIR, "{sample}.geneBodyCoverage.txt")
 
-    params:
-        # samples = lambda wildcards, input: ",".join(input.bams),
-        annotation = BED12,
-        prefix = os.path.join(RSEQC_OUTDIR, "{sample}")
+#     params:
+#         # samples = lambda wildcards, input: ",".join(input.bams),
+#         annotation = BED12,
+#         prefix = os.path.join(RSEQC_OUTDIR, "{sample}")
 
-    conda:
-        "../env/align.yaml"
+#     conda:
+#         "../env/align.yaml"
 
-    shell:
-        """
-        geneBody_coverage.py \
-        -i {input.bam} \
-        -r {params.annotation} \
-        -l 100 \
-        -o {params.prefix}
-        """
+#     shell:
+#         """
+#         geneBody_coverage.py \
+#         -i {input.bam} \
+#         -r {params.annotation} \
+#         -l 100 \
+#         -o {params.prefix}
+#         """
 
 
 rule infer_experiment:


### PR DESCRIPTION
discussed in #38, but after recently running the pipeline on ~50 million paired end read samples this step was frustratingly slow (~5 hours for a single sample). It is a useful plot, but I don't think it's so critical to have by default (and there are likely quicker options if so). Quick fix for now is to remove, long term a proper refactor is likely needed.

Successfully dry runs with test data and I've run a pipeline through this branch on the cluster
![Screenshot 2024-04-10 124801-genebody-rm-successful-dryrun](https://github.com/frattalab/rna_seq_snakemake/assets/49978382/1b4ad940-0437-4369-a8cc-f7782cb71dc5)
 