### PR TITLE
rseqc.smk - fix BAM index file names in input

### DIFF
--- a/rules/rseqc.smk
+++ b/rules/rseqc.smk
@@ -82,7 +82,7 @@ rule all_rseqc:
 rule infer_experiment:
     input:
         bam = os.path.join(STAR_OUTDIR, "{sample}.Aligned.sorted.out.bam"),
-        idx = os.path.join(STAR_OUTDIR, "{sample}.Aligned.sorted.out.bam")
+        idx = os.path.join(STAR_OUTDIR, "{sample}.Aligned.sorted.out.bam.bai")
 
     output:
         os.path.join(RSEQC_OUTDIR, "{sample}.infer_experiment.txt")
@@ -107,7 +107,7 @@ rule infer_experiment:
 rule inner_distance_freq:
     input:
         bam = os.path.join(STAR_OUTDIR, "{sample}.Aligned.sorted.out.bam"),
-        idx = os.path.join(STAR_OUTDIR, "{sample}.Aligned.sorted.out.bam")
+        idx = os.path.join(STAR_OUTDIR, "{sample}.Aligned.sorted.out.bam.bai")
 
     output:
         os.path.join(RSEQC_OUTDIR, "{sample}.inner_distance_freq.txt")
@@ -130,7 +130,7 @@ rule inner_distance_freq:
 rule junction_saturation:
     input:
         bam = os.path.join(STAR_OUTDIR, "{sample}.Aligned.sorted.out.bam"),
-        idx = os.path.join(STAR_OUTDIR, "{sample}.Aligned.sorted.out.bam")
+        idx = os.path.join(STAR_OUTDIR, "{sample}.Aligned.sorted.out.bam.bai")
 
     output:
         os.path.join(RSEQC_OUTDIR, "{sample}.junctionSaturation_plot.r")
@@ -153,7 +153,7 @@ rule junction_saturation:
 rule read_distribution:
     input:
         bam = os.path.join(STAR_OUTDIR, "{sample}.Aligned.sorted.out.bam"),
-        idx = os.path.join(STAR_OUTDIR, "{sample}.Aligned.sorted.out.bam")
+        idx = os.path.join(STAR_OUTDIR, "{sample}.Aligned.sorted.out.bam.bai")
 
     output:
         os.path.join(RSEQC_OUTDIR, "{sample}.read_distribution.txt")


### PR DESCRIPTION
closes #59 

Successful dry run here:
<img width="949" alt="image" src="https://github.com/frattalab/rna_seq_snakemake/assets/49978382/bc4feecb-1c4f-4a7f-babc-59eca2fdf6bd">
